### PR TITLE
Use custom encoding instead of url encoding

### DIFF
--- a/Sources/DocUploadBundle/DocUploadBundle.swift
+++ b/Sources/DocUploadBundle/DocUploadBundle.swift
@@ -74,7 +74,7 @@ public struct DocUploadBundle {
     public let s3Folder: S3Folder
 
     var archiveName: String {
-        "\(env)-\(repository.owner)-\(repository.name)-\(reference.urlEncoded)-\(self.uuid().firstSegment).zip"
+        "\(env)-\(repository.owner)-\(repository.name)-\(reference.pathEncoded)-\(self.uuid().firstSegment).zip"
             .lowercased()
     }
 
@@ -97,7 +97,7 @@ public struct DocUploadBundle {
         self.env = bucket.droppingSPIPrefix().droppingDocsSuffix()
         self.s3Folder = .init(
             bucket: bucket,
-            path: "\(repository.owner)/\(repository.name)/\(reference.urlEncoded)".lowercased()
+            path: "\(repository.owner)/\(repository.name)/\(reference.pathEncoded)".lowercased()
         )
         self.metadata = .init(
             apiBaseURL: apiBaseURL,

--- a/Sources/DocUploadBundle/String+ext.swift
+++ b/Sources/DocUploadBundle/String+ext.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 extension String {
-    public var urlEncoded: Self {
-        addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? self
+    public var pathEncoded: Self {
+        replacingOccurrences(of: "/", with: ".")
     }
 }

--- a/Tests/DocUploadBundleTests/DocUploadBundleTests.swift
+++ b/Tests/DocUploadBundleTests/DocUploadBundleTests.swift
@@ -53,13 +53,13 @@ final class DocUploadBundleTests: XCTestCase {
                        .init(bucket: "spi-prod-docs", path: "owner/name/branch"))
     }
 
-    func test_String_urlEncoded() throws {
-        XCTAssertEqual("main".urlEncoded, "main")
-        XCTAssertEqual("1.2.3".urlEncoded, "1.2.3")
-        XCTAssertEqual("0.50900.0-swift-DEVELOPMENT-SNAPSHOT-2023-02-27-a".urlEncoded,
+    func test_String_pathEncoded() throws {
+        XCTAssertEqual("main".pathEncoded, "main")
+        XCTAssertEqual("1.2.3".pathEncoded, "1.2.3")
+        XCTAssertEqual("0.50900.0-swift-DEVELOPMENT-SNAPSHOT-2023-02-27-a".pathEncoded,
                        "0.50900.0-swift-DEVELOPMENT-SNAPSHOT-2023-02-27-a")
-        XCTAssertEqual("foo/bar".urlEncoded, "foo%2Fbar")
-        XCTAssertEqual("v1.2.3-beta1+build5".urlEncoded, "v1.2.3-beta1+build5")
+        XCTAssertEqual("foo/bar".pathEncoded, "foo.bar")
+        XCTAssertEqual("v1.2.3-beta1+build5".pathEncoded, "v1.2.3-beta1+build5")
     }
 
     func test_issue_10() throws {
@@ -80,7 +80,7 @@ final class DocUploadBundleTests: XCTestCase {
                             fileCount: 123,
                             mbSize: 456)
         }
-        XCTAssertEqual(bundle.archiveName, "prod-owner-name-feature%2f2.0.0-cafecafe.zip")
+        XCTAssertEqual(bundle.archiveName, "prod-owner-name-feature.2.0.0-cafecafe.zip")
     }
 
 }

--- a/Tests/DocUploadBundleTests/DocUploadBundleTests.swift
+++ b/Tests/DocUploadBundleTests/DocUploadBundleTests.swift
@@ -69,7 +69,7 @@ final class DocUploadBundleTests: XCTestCase {
         let bundle = withDependencies {
             $0.uuid = .constant(cafe)
         } operation: {
-            DocUploadBundle(sourcePath: "/path",
+            DocUploadBundle(sourcePath: "/owner/name/feature.2.0.0",
                             bucket: "spi-prod-docs",
                             repository: .init(owner: "Owner", name: "Name"),
                             reference: "feature/2.0.0",
@@ -81,6 +81,19 @@ final class DocUploadBundleTests: XCTestCase {
                             mbSize: 456)
         }
         XCTAssertEqual(bundle.archiveName, "prod-owner-name-feature.2.0.0-cafecafe.zip")
+        XCTAssertEqual(bundle.metadata,
+                       .init(
+                           apiBaseURL: "baseURL",
+                           apiToken: "token",
+                           buildId: cafe,
+                           docArchives: [.init(name: "foo", title: "Foo")],
+                           fileCount: 123,
+                           mbSize: 456,
+                           sourcePath: "feature.2.0.0",
+                           targetFolder: bundle.s3Folder)
+                       )
+        XCTAssertEqual(bundle.s3Folder,
+                       .init(bucket: "spi-prod-docs", path: "owner/name/feature.2.0.0"))
     }
 
 }


### PR DESCRIPTION
We can't actually use url encoding, because S3 then double encodes the `%` in `%2f`:

```
2023-03-09T08:30:05+0000 info Lambda : lifecycleIteration=2 [DocUploader] file: s3://spi-scratch-inbox/dev-linhay-sectionkit-feature%252f2.0.0-e97a5cc0.zip
```

Trying simply `/` → `.` instead. While this isn't reversible it shouldn't matter, because it surfaces downstream, i.e. we shouldn't have need for reversing it.

This is hard to test end-to-end before deploying changes so we'll have to do this live.