### PR TITLE
Package update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+# Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI
+
+on:
+    workflow_dispatch:
+    push:
+        branches: [ main ]
+    pull_request:
+        branches: [ main ]
+
+jobs:
+    tests:
+        runs-on: ubuntu-latest
+        container:
+            image: swift:5.8.0-amazonlinux2
+        steps:
+            - name: Run tests
+              run: swift test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,7 @@ jobs:
         container:
             image: swift:5.8.0-amazonlinux2
         steps:
+            - name: Checkout
+              uses: actions/checkout@v3
             - name: Run tests
               run: swift test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,19 @@
 name: CI
 
 on:
-    workflow_dispatch:
-    push:
-        branches: [ main ]
-    pull_request:
-        branches: [ main ]
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
-    tests:
-        runs-on: ubuntu-latest
-        container:
-            image: swift:5.8.0-amazonlinux2
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-            - name: Run tests
-              run: swift test
+  tests:
+    runs-on: ubuntu-latest
+    container:
+      image: swift:5.8.0-amazonlinux2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run tests
+        run: swift test

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "7f05a8da46cc2a4ab43218722298b81ac7a08031",
-        "version" : "1.13.2"
+        "revision" : "864c8d9e0ead5de7ba70b61c8982f89126710863",
+        "version" : "1.15.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/soto-project/soto.git",
       "state" : {
-        "revision" : "258094b83797fb9ad4fe3882b1a6a46a92d2c2ae",
-        "version" : "6.4.0"
+        "revision" : "26bd91a43a3e569956b99b7f15aa2709a1a6ff23",
+        "version" : "6.5.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/soto-project/soto-core.git",
       "state" : {
-        "revision" : "cf1c872126e4874144ed2f91aa2124e72388abe0",
-        "version" : "6.4.1"
+        "revision" : "787be995b0cff07bd28e9aea4c8a6424ead36e71",
+        "version" : "6.4.2"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "ff3d2212b6b093db7f177d0855adbc4ef9c5f036",
-        "version" : "1.0.3"
+        "revision" : "6c89474e62719ddcc1e9614989fff2f68208fe10",
+        "version" : "1.1.0"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies.git",
       "state" : {
-        "revision" : "8282b0c59662eb38946afe30eb403663fc2ecf76",
-        "version" : "0.1.4"
+        "revision" : "0f34848e741315119703b1990e5c962929ed5dff",
+        "version" : "0.3.0"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "6fe203dc33195667ce1759bf0182975e4653ba1c",
-        "version" : "1.4.4"
+        "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
+        "version" : "1.5.2"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "9b39d811a83cf18b79d7d5513b06f8b290198b10",
-        "version" : "2.3.3"
+        "revision" : "e8bced74bc6d747745935e469f45d03f048d6cbd",
+        "version" : "2.3.4"
       }
     },
     {
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "e855380cb5234e96b760d93e0bfdc403e381e928",
-        "version" : "2.45.0"
+        "revision" : "e0cc6dd6ffa8e6a6f565938acd858b24e47902d0",
+        "version" : "2.50.0"
       }
     },
     {
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "91dd2d61fb772e1311bb5f13b59266b579d77e42",
-        "version" : "1.15.0"
+        "revision" : "0e0d0aab665ff1a0659ce75ac003081f2b1c8997",
+        "version" : "1.19.0"
       }
     },
     {
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "d6656967f33ed8b368b38e4b198631fc7c484a40",
-        "version" : "1.23.1"
+        "revision" : "38feec96bcd929028939107684073554bf01abeb",
+        "version" : "1.25.2"
       }
     },
     {
@@ -185,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "c0d9a144cfaec8d3d596aadde3039286a266c15c",
-        "version" : "1.15.0"
+        "revision" : "59b966415dd336db6f388bbfe3fb43cfa549b981",
+        "version" : "1.16.0"
       }
     },
     {
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "16b23a295fa322eb957af98037f86791449de60f",
-        "version" : "0.8.1"
+        "revision" : "ab8c9f45843694dd16be4297e6d44c0634fd9913",
+        "version" : "0.8.4"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "864c8d9e0ead5de7ba70b61c8982f89126710863",
-        "version" : "1.15.0"
+        "revision" : "5b4f03de0600da906f9e46e9f636ec26218da080",
+        "version" : "1.16.0"
       }
     },
     {
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "4fb7ead803e38949eb1d6fabb849206a72c580f3",
-        "version" : "2.23.0"
+        "revision" : "9d0d5d8798a576fbf674a823734e65e15ca5f2ec",
+        "version" : "2.23.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies.git",
       "state" : {
-        "revision" : "6bb1034e8a1bfbf46dfb766b6c09b7b17e1cba10",
-        "version" : "0.2.0"
+        "revision" : "615833420b3a01cec57530cae1287ee70dfdb77c",
+        "version" : "0.4.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -109,6 +109,15 @@
       }
     },
     {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "da0fe44138ab86e380f40a2acbd8a611b07d3f64",
+        "version" : "2.4.0"
+      }
+    },
+    {
       "identity" : "swift-dependencies",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies.git",

--- a/Package.resolved
+++ b/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies.git",
       "state" : {
-        "revision" : "0f34848e741315119703b1990e5c962929ed5dff",
-        "version" : "0.3.0"
+        "revision" : "6bb1034e8a1bfbf46dfb766b6c09b7b17e1cba10",
+        "version" : "0.2.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -109,15 +109,6 @@
       }
     },
     {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "da0fe44138ab86e380f40a2acbd8a611b07d3f64",
-        "version" : "2.4.0"
-      }
-    },
-    {
       "identity" : "swift-dependencies",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies.git",

--- a/Package.resolved
+++ b/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-aws-lambda-events.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "a8c815ef37f9dbd2262b20910c926ba5f3141bde"
+        "revision" : "8e836e0893bc906fafd6b09e1c46a7efcc441fd5",
+        "version" : "0.1.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-aws-lambda-runtime.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "dc64ce195b1c51356f6655935c3509e296c35696"
+        "revision" : "de730b240df25897c4b5b68889c178c994fd6817",
+        "version" : "1.0.0-alpha.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha.1"),
         .package(url: "https://github.com/soto-project/soto-s3-file-transfer.git", from: "1.2.0"),
         .package(url: "https://github.com/marmelroy/Zip.git", from: "2.1.2"),
-        .package(url: "https://github.com/pointfreeco/swift-dependencies.git", from: "0.1.4")
+        .package(url: "https://github.com/pointfreeco/swift-dependencies.git", exact: "0.2.0")
     ],
     targets: [
         .executableTarget(name: "Executable", dependencies: ["DocUploader"]),

--- a/Package.swift
+++ b/Package.swift
@@ -24,9 +24,6 @@ let package = Package(
         .library(name: "DocUploadBundle", targets: ["DocUploadBundle"])
     ],
     dependencies: [
-        // Fixe Linux package resollution error:
-        // error: 'swift-crypto': Error Domain=NSCocoaErrorDomain Code=513 "You don’t have permission."
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.0.0"),
         .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", from: "0.1.0"),
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha.1"),
         .package(url: "https://github.com/soto-project/soto-s3-file-transfer.git", from: "1.2.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha.1"),
         .package(url: "https://github.com/soto-project/soto-s3-file-transfer.git", from: "1.2.0"),
         .package(url: "https://github.com/marmelroy/Zip.git", from: "2.1.2"),
+        // FIXME: unpin after https://github.com/pointfreeco/swift-dependencies/issues/79 is resolved
         .package(url: "https://github.com/pointfreeco/swift-dependencies.git", exact: "0.2.0")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,9 @@ let package = Package(
         .library(name: "DocUploadBundle", targets: ["DocUploadBundle"])
     ],
     dependencies: [
+        // Fixe Linux package resollution error:
+        // error: 'swift-crypto': Error Domain=NSCocoaErrorDomain Code=513 "You don’t have permission."
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.0.0"),
         .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", from: "0.1.0"),
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha.1"),
         .package(url: "https://github.com/soto-project/soto-s3-file-transfer.git", from: "1.2.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,8 @@ let package = Package(
         .library(name: "DocUploadBundle", targets: ["DocUploadBundle"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", branch: "main"),
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", branch: "main"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", from: "0.1.0"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha.1"),
         .package(url: "https://github.com/soto-project/soto-s3-file-transfer.git", from: "1.2.0"),
         .package(url: "https://github.com/marmelroy/Zip.git", from: "2.1.2"),
         .package(url: "https://github.com/pointfreeco/swift-dependencies.git", from: "0.1.4")

--- a/Package.swift
+++ b/Package.swift
@@ -28,8 +28,7 @@ let package = Package(
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha.1"),
         .package(url: "https://github.com/soto-project/soto-s3-file-transfer.git", from: "1.2.0"),
         .package(url: "https://github.com/marmelroy/Zip.git", from: "2.1.2"),
-        // FIXME: unpin after https://github.com/pointfreeco/swift-dependencies/issues/79 is resolved
-        .package(url: "https://github.com/pointfreeco/swift-dependencies.git", exact: "0.2.0")
+        .package(url: "https://github.com/pointfreeco/swift-dependencies.git", from: "0.4.0")
     ],
     targets: [
         .executableTarget(name: "Executable", dependencies: ["DocUploader"]),

--- a/README.md
+++ b/README.md
@@ -33,3 +33,31 @@ make deploy-test
 ## Lambda operation notes
 
 https://docs.aws.amazon.com/lambda/latest/operatorguide/computing-power.html
+
+## Release testing
+
+There is currently no automated test setup to validate a new release, because it would be quite complex to set up.
+
+Instead, use the `dev` environment to validate a new release as follows:
+
+- Deploy the new version to the "test" lambda
+
+```
+make deploy-test
+```
+
+- Trigger a doc upload via the "test" lambda by downloading a `dev-` doc bundle from `spi-docs-inbox` and uploading it to `spi-scratch-inbox`:
+
+```bash
+❯ aws s3 cp s3://spi-docs-inbox/dev-swiftpackageindex-semanticversion-0.3.4-4e7b8a37.zip .
+❯ aws s3 cp dev-swiftpackageindex-semanticversion-0.3.4-4e7b8a37.zip s3://spi-scratch-inbox/
+```
+
+- Verify docs updated in `spi-dev-docs` for the given package (either by checking the timestamp or by deleting the version first and ensuring it re-appears)
+
+## Pushing a new release
+
+Once a new release has been validated, push a new release as follows:
+
+- Tag the version
+- Run `make deploy-prod`

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ make deploy-test
 ❯ aws s3 cp dev-swiftpackageindex-semanticversion-0.3.4-4e7b8a37.zip s3://spi-scratch-inbox/
 ```
 
-- Verify docs updated in `spi-dev-docs` for the given package (either by checking the timestamp or by deleting the version first and ensuring it re-appears)
+- Check the `DocUploaderLambda-Test` CloudWatch log group to confirm the new version has been triggered and processed the file without errors.
+
+- Verify docs updated in `spi-dev-docs` for the given package (either by checking the timestamp or by deleting the version first and ensuring it re-appears).
 
 ## Pushing a new release
 
@@ -67,3 +69,16 @@ Once a new release has been validated, push a new release as follows:
 
 - Tag the version
 - Run `make deploy-prod`
+
+## Installing and updating SAM
+
+Install:
+```
+brew tap aws/tap
+brew install aws-sam-cli
+```
+
+Update:
+```
+brew upgrade aws-sam-cli
+```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ There is currently no automated test setup to validate a new release, because it
 
 Instead, use the `dev` environment to validate a new release as follows:
 
+- Run the tests
+
+```
+docker run --rm -v "$PWD":/host -w /host swift:5.8.0-amazonlinux2 swift test
+```
+
 - Deploy the new version to the "test" lambda
 
 ```

--- a/Tests/DocUploadBundleTests/DocUploadBundleTests.swift
+++ b/Tests/DocUploadBundleTests/DocUploadBundleTests.swift
@@ -58,7 +58,7 @@ final class DocUploadBundleTests: XCTestCase {
         XCTAssertEqual("1.2.3".pathEncoded, "1.2.3")
         XCTAssertEqual("0.50900.0-swift-DEVELOPMENT-SNAPSHOT-2023-02-27-a".pathEncoded,
                        "0.50900.0-swift-DEVELOPMENT-SNAPSHOT-2023-02-27-a")
-        XCTAssertEqual("foo/bar".pathEncoded, "foo.bar")
+        XCTAssertEqual("foo/bar".pathEncoded, "foo-bar")
         XCTAssertEqual("v1.2.3-beta1+build5".pathEncoded, "v1.2.3-beta1+build5")
     }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,5 +22,5 @@ docker run \
   --rm \
   --volume "$(pwd):/src" \
   --workdir "/src" \
-  swift:5.7.1-amazonlinux2 \
+  swift:5.8.0-amazonlinux2 \
   swift build --product "$executable" -c release --static-swift-stdlib #-Xswiftc -cross-module-optimization 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,4 +23,4 @@ docker run \
   --volume "$(pwd):/src" \
   --workdir "/src" \
   swift:5.8.0-amazonlinux2 \
-  swift build --product "$executable" -c release --static-swift-stdlib #-Xswiftc -cross-module-optimization 
+  swift build --disable-automatic-resolution --product "$executable" -c release --static-swift-stdlib #-Xswiftc -cross-module-optimization 


### PR DESCRIPTION
- move to Swift 5.8
- change dependencies to release version so we can use DocUploader as a dependency in spi-builder