### PR TITLE
Add linkablePathsCount to Metadata, report it back

### DIFF
--- a/Sources/DocUploadBundle/DocUploadBundle.swift
+++ b/Sources/DocUploadBundle/DocUploadBundle.swift
@@ -56,6 +56,7 @@ public struct DocUploadBundle {
         public var buildId: UUID
         public var docArchives: [DocArchive]
         public var fileCount: Int?
+        public var linkablePathsCount: Int?
         public var mbSize: Int?
 
         /// Basename of the doc set source directory after unzipping. The value will be the source code revision, e.g. "1.2.3" or "main".
@@ -88,6 +89,7 @@ public struct DocUploadBundle {
         buildId: UUID,
         docArchives: [DocArchive],
         fileCount: Int? = nil,
+        linkablePathsCount: Int? = nil,
         mbSize: Int? = nil
     ) {
         self.sourcePath = sourcePath
@@ -105,6 +107,7 @@ public struct DocUploadBundle {
             buildId: buildId,
             docArchives: docArchives,
             fileCount: fileCount,
+            linkablePathsCount: linkablePathsCount,
             mbSize: mbSize,
             sourcePath: URL(fileURLWithPath: sourcePath).lastPathComponent.lowercased(),
             targetFolder: s3Folder

--- a/Sources/DocUploader/DocReport.swift
+++ b/Sources/DocUploader/DocReport.swift
@@ -34,6 +34,7 @@ enum DocReport {
         var docArchives: [DocArchive]
         var error: String?
         var fileCount: Int?
+        var linkablePathsCount: Int?
         var logUrl: String?
         var mbSize: Int?
         var status: Status

--- a/Sources/DocUploader/DocUploader.swift
+++ b/Sources/DocUploader/DocUploader.swift
@@ -141,6 +141,7 @@ public struct DocUploader: LambdaHandler {
                         dto: .init(docArchives: metadata.docArchives,
                                    error: result.error,
                                    fileCount: metadata.fileCount,
+                                   linkablePathsCount: metadata.linkablePathsCount,
                                    logUrl: Self.logURL(),
                                    mbSize: metadata.mbSize,
                                    status: result.status)

--- a/Tests/DocUploadBundleTests/DocUploadBundleTests.swift
+++ b/Tests/DocUploadBundleTests/DocUploadBundleTests.swift
@@ -35,6 +35,7 @@ final class DocUploadBundleTests: XCTestCase {
                             buildId: cafe,
                             docArchives: [.init(name: "foo", title: "Foo")],
                             fileCount: 123,
+                            linkablePathsCount: 234,
                             mbSize: 456)
         }
         XCTAssertEqual(bundle.archiveName, "prod-owner-name-branch-cafecafe.zip")
@@ -45,6 +46,7 @@ final class DocUploadBundleTests: XCTestCase {
                            buildId: cafe,
                            docArchives: [.init(name: "foo", title: "Foo")],
                            fileCount: 123,
+                           linkablePathsCount: 234,
                            mbSize: 456,
                            sourcePath: "branch",
                            targetFolder: bundle.s3Folder)
@@ -78,6 +80,7 @@ final class DocUploadBundleTests: XCTestCase {
                             buildId: cafe,
                             docArchives: [.init(name: "foo", title: "Foo")],
                             fileCount: 123,
+                            linkablePathsCount: 234,
                             mbSize: 456)
         }
         XCTAssertEqual(bundle.archiveName, "prod-owner-name-feature-2.0.0-cafecafe.zip")
@@ -88,6 +91,7 @@ final class DocUploadBundleTests: XCTestCase {
                            buildId: cafe,
                            docArchives: [.init(name: "foo", title: "Foo")],
                            fileCount: 123,
+                           linkablePathsCount: 234,
                            mbSize: 456,
                            sourcePath: "feature-2.0.0",
                            targetFolder: bundle.s3Folder)

--- a/Tests/DocUploaderTests/DocUploaderTests.swift
+++ b/Tests/DocUploaderTests/DocUploaderTests.swift
@@ -50,6 +50,7 @@ final class DocUploaderTests: XCTestCase {
                 dto: .init(docArchives: [.init(name: "foo", title: "Foo")],
                            error: "too big",
                            fileCount: 1_234,
+                           linkablePathsCount: 234,
                            logUrl: "log url 1",
                            mbSize: 123,
                            status: .skipped))


### PR DESCRIPTION
We need to report `linkablePathsCount` via the doc uploader, else we'll just reset it to `NULL` when it reports in.