### PR TITLE
Hang workaround

### DIFF
--- a/Sources/DocUploadBundle/DocUploadBundle.swift
+++ b/Sources/DocUploadBundle/DocUploadBundle.swift
@@ -14,21 +14,14 @@
 
 import Foundation
 
-#if swift(>=5.6)
-// Swift5.5Tests need to run with Swift 5.5 but swift-dependencies has tools-version 5.6
 import Dependencies
-#endif
 import Zip
 
 
 public struct DocUploadBundle {
 
-#if swift(>=5.6)
-    // Swift5.5Tests need to run with Swift 5.5 but swift-dependencies has tools-version 5.6
-    @Dependency(\.uuid) var uuid
-#else
+//    @Dependency(\.uuid) var uuid
     let uuid = { UUID() }
-#endif
 
     public struct S3Folder: Codable, Equatable {
         public var bucket: String

--- a/Sources/DocUploadBundle/DocUploadBundle.swift
+++ b/Sources/DocUploadBundle/DocUploadBundle.swift
@@ -20,8 +20,11 @@ import Zip
 
 public struct DocUploadBundle {
 
-//    @Dependency(\.uuid) var uuid
+#if DEBUG
+    @Dependency(\.uuid) var uuid
+#else
     let uuid = { UUID() }
+#endif
 
     public struct S3Folder: Codable, Equatable {
         public var bucket: String

--- a/Sources/DocUploadBundle/DocUploadBundle.swift
+++ b/Sources/DocUploadBundle/DocUploadBundle.swift
@@ -20,6 +20,7 @@ import Zip
 
 public struct DocUploadBundle {
 
+    // Workaround for https://github.com/pointfreeco/swift-dependencies/issues/199
 #if DEBUG
     @Dependency(\.uuid) var uuid
 #else

--- a/Sources/DocUploader/Dependencies/HTTPExecutor.swift
+++ b/Sources/DocUploader/Dependencies/HTTPExecutor.swift
@@ -36,14 +36,5 @@ extension HTTPExecutor {
 }
 
 extension HTTPExecutor: DependencyKey {
-    static var liveValue: HTTPExecutor {
-        .live
-    }
-}
-
-extension DependencyValues {
-    var httpClient: HTTPExecutor {
-        get { self[HTTPExecutor.self] }
-        set { self[HTTPExecutor.self] = newValue }
-    }
+    static var liveValue: HTTPExecutor { .live }
 }

--- a/Sources/DocUploader/DocReport.swift
+++ b/Sources/DocUploader/DocReport.swift
@@ -22,6 +22,7 @@ import NIOHTTP1
 
 enum DocReport {
 
+    // Workaround for https://github.com/pointfreeco/swift-dependencies/issues/199
 #if DEBUG
     @Dependency(HTTPExecutor.self) static var httpClient: HTTPExecutor
 #else

--- a/Sources/DocUploader/DocReport.swift
+++ b/Sources/DocUploader/DocReport.swift
@@ -22,7 +22,11 @@ import NIOHTTP1
 
 enum DocReport {
 
-    @Dependency(\.httpClient) static var httpClient: HTTPExecutor
+#if DEBUG
+    @Dependency(HTTPExecutor.self) static var httpClient: HTTPExecutor
+#else
+    static let httpClient: HTTPExecutor = .live
+#endif
 
     enum Status: String, Codable {
         case ok

--- a/Tests/DocUploaderTests/DocUploaderTests.swift
+++ b/Tests/DocUploaderTests/DocUploaderTests.swift
@@ -35,7 +35,7 @@ final class DocUploaderTests: XCTestCase {
     func test_reportResult() async throws {
         var request: HTTPClientRequest?
         try await withDependencies {
-            $0.httpClient.execute = { _, req, _ in
+            $0[HTTPExecutor.self].execute = { _, req, _ in
                 request = req
                 return .init(status: .noContent)
             }


### PR DESCRIPTION
This is working around a hang in our builder when updating to swift-dependencies 1.2.x

Upstream tracking issue: https://github.com/pointfreeco/swift-dependencies/issues/199