### PR TITLE
Switch zip library

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -244,12 +244,12 @@
       }
     },
     {
-      "identity" : "zip",
+      "identity" : "zipfoundation",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/marmelroy/Zip.git",
+      "location" : "https://github.com/weichsel/ZIPFoundation.git",
       "state" : {
-        "revision" : "67fa55813b9e7b3b9acee9c0ae501def28746d76",
-        "version" : "2.1.2"
+        "revision" : "02b6abe5f6eef7e3cbd5f247c5cc24e246efcfe0",
+        "version" : "0.9.19"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", from: "0.1.0"),
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha.1"),
         .package(url: "https://github.com/soto-project/soto-s3-file-transfer.git", from: "1.2.0"),
-        .package(url: "https://github.com/marmelroy/Zip.git", from: "2.1.2"),
+        .package(url: "https://github.com/weichsel/ZIPFoundation.git", from: "0.9.19"),
         .package(url: "https://github.com/pointfreeco/swift-dependencies.git", from: "1.0.0")
     ],
     targets: [
@@ -56,7 +56,7 @@ let package = Package(
             linkerSettings: linkerSettings
         ),
         .target(name: "DocUploadBundle", dependencies: [
-            .product(name: "Zip", package: "Zip"),
+            .product(name: "ZIPFoundation", package: "zipfoundation"),
             .product(name: "Dependencies", package: "swift-dependencies")
         ]),
         .testTarget(name: "DocUploadBundleTests", dependencies: ["DocUploadBundle"], exclude: ["Fixtures"]),

--- a/Sources/DocUploadBundle/Zipper.swift
+++ b/Sources/DocUploadBundle/Zipper.swift
@@ -14,16 +14,20 @@
 
 import Foundation
 
-import Zip
+import ZIPFoundation
 
 
 enum Zipper {
     static func zip(paths inputPaths: [URL], to outputPath: URL) throws {
-        try Zip.zipFiles(paths: inputPaths, zipFilePath: outputPath, password: nil, progress: nil)
+        let archive = try Archive(url: outputPath, accessMode: .create)
+        for url in inputPaths {
+            try archive.addEntry(with: url.lastPathComponent, fileURL: url)
+        }
     }
 
     static func unzip(from inputPath: URL, to outputPath: URL, fileOutputHandler: ((_ unzippedFile: URL) -> Void)? = nil) throws {
-        try Zip.unzipFile(inputPath, destination: outputPath, overwrite: true, password: nil, fileOutputHandler: fileOutputHandler)
+        try FileManager.default.createDirectory(at: outputPath, withIntermediateDirectories: true)
+        try FileManager.default.unzipItem(at: inputPath, to: outputPath)
     }
 }
 


### PR DESCRIPTION
We'll lose the progress logging:

![CleanShot 2024-05-27 at 15 09 12@2x](https://github.com/SwiftPackageIndex/DocUploader/assets/65520/273d6d6b-795b-4b7d-950a-f62786b42c84)

However, we also only logged every 5000th file, so this isn't something critical.