### PR TITLE
Bump soto-s3-file-transfer to 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ DerivedData/
 .netrc
 /.lambda/
 /.vscode/
+.swiftpm/

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "291438696abdd48d2a83b52465c176efbd94512b",
-        "version" : "1.20.1"
+        "revision" : "333f51104b75d1a5b94cb3b99e4c58a3b442c9f7",
+        "version" : "1.25.2"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/soto-project/soto.git",
       "state" : {
-        "revision" : "c28c3efa72e6beceae6f38f8c8fe18e7c57e3418",
-        "version" : "6.8.0"
+        "revision" : "141b3c944f3f4a9ad428280e8ad94f6f437e0f00",
+        "version" : "7.5.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/soto-project/soto-core.git",
       "state" : {
-        "revision" : "3ed66ec536bc372360d7e3ec39a5e8b1870747ea",
-        "version" : "6.5.2"
+        "revision" : "a61299aa18626e462312984765d34146286b29d3",
+        "version" : "7.4.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/soto-project/soto-s3-file-transfer.git",
       "state" : {
-        "revision" : "da375d7544080e8f00dba3bb573d7a412f3c4b41",
-        "version" : "1.3.0"
+        "revision" : "5104491d1a8f76a2839e4476e9644b3885ba758c",
+        "version" : "2.1.0"
       }
     },
     {
@@ -136,6 +136,15 @@
       }
     },
     {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "a64a0abc2530f767af15dd88dda7f64d5f1ff9de",
+        "version" : "1.2.0"
+      }
+    },
+    {
       "identity" : "swift-http-types",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types",
@@ -167,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "fc63f0cf4e55a4597407a9fc95b16a2bc44b4982",
-        "version" : "2.64.0"
+        "revision" : "c51907a839e63ebf0ba2076bba73dd96436bd1b9",
+        "version" : "2.81.0"
       }
     },
     {
@@ -194,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "7c381eb6083542b124a6c18fae742f55001dc2b5",
-        "version" : "2.26.0"
+        "revision" : "0cc3528ff48129d64ab9cab0b1cd621634edfc6b",
+        "version" : "2.29.3"
       }
     },
     {
@@ -217,6 +226,15 @@
       }
     },
     {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "8946c930cae601452149e45d31d8ddfac973c3c7",
+        "version" : "1.2.0"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
@@ -230,8 +248,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "025bcb1165deab2e20d4eaba79967ce73013f496",
-        "version" : "1.2.1"
+        "revision" : "a34201439c74b53f0fd71ef11741af7e7caf01e1",
+        "version" : "1.4.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
         .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", from: "0.1.0"),
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha.1"),
-        .package(url: "https://github.com/soto-project/soto-s3-file-transfer.git", from: "1.2.0"),
+        .package(url: "https://github.com/soto-project/soto-s3-file-transfer.git", from: "2.0.0"),
         .package(url: "https://github.com/vapor-community/Zip.git", from: "2.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-dependencies.git", from: "1.0.0")
     ],

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Instead, use the `dev` environment to validate a new release as follows:
 - Run the tests
 
     ```
-    docker run --rm -v "$PWD":/host -w /host swift:5.10.0-amazonlinux2 swift test
+    docker run --rm -v "$PWD":/host -w /host swift:6.0.3-amazonlinux2 swift test
     ```
 
 - Deploy the new version to the "test" lambda

--- a/Sources/DocUploader/DocUploader.swift
+++ b/Sources/DocUploader/DocUploader.swift
@@ -48,16 +48,11 @@ public struct DocUploader: LambdaHandler {
         }
         self.httpClient = httpClient
 
-        let awsClient = AWSClient(httpClientProvider: .shared(httpClient))
+        let awsClient = AWSClient(httpClient: httpClient)
         context.terminator.register(name: "awsclient") { eventLoop in
             let promise = eventLoop.makePromise(of: Void.self)
-            awsClient.shutdown() { error in
-                switch error {
-                case .none:
-                    promise.succeed(())
-                case .some(let error):
-                    promise.fail(error)
-                }
+            promise.completeWithTask {
+                try await awsClient.shutdown()
             }
             return promise.futureResult
         }

--- a/Sources/DocUploader/LiveS3Client.swift
+++ b/Sources/DocUploader/LiveS3Client.swift
@@ -50,11 +50,11 @@ struct LiveS3Client: S3Client {
             throw Error(message: "Invalid key: \(key)")
         }
 
-        var nextProgressTick = 0.1
+        let nextProgressTick = QueueIsolated(0.1)
         try await s3FileTransfer.sync(from: folder, to: s3Folder, delete: true) { progress in
-            if progress >= nextProgressTick {
+            if progress >= nextProgressTick.value {
                 logger.info("Syncing... [\(percent: progress)]")
-                nextProgressTick += 0.1
+                nextProgressTick.withValue { $0 += 0.1 }
             }
         }
     }

--- a/Sources/DocUploader/LiveS3Client.swift
+++ b/Sources/DocUploader/LiveS3Client.swift
@@ -15,7 +15,6 @@
 import NIO
 import SotoS3
 import SotoS3FileTransfer
-import Synchronization
 
 
 struct LiveS3Client: S3Client {

--- a/Sources/DocUploader/QueueIsolated.swift
+++ b/Sources/DocUploader/QueueIsolated.swift
@@ -1,0 +1,69 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+
+// Modeled after ActorIsolated with synchronisation via a queue instead of an actor, allowing
+// sync access where async isn't possible.
+
+@dynamicMemberLookup
+public final class QueueIsolated<Value: Sendable>: @unchecked Sendable {
+    private let _queue = DispatchQueue(label: "queue-isolated")
+
+    private var _value: Value
+
+    public init(_ value: Value) {
+        self._value = value
+    }
+
+    public var value: Value {
+        get {
+            _queue.sync { self._value }
+        }
+    }
+
+    public subscript<Subject>(dynamicMember keyPath: KeyPath<Value, Subject>) -> Subject {
+        _queue.sync {
+            self._value[keyPath: keyPath]
+        }
+    }
+
+    public func withValue<T>(
+        _ operation: (inout Value) throws -> T
+    ) rethrows -> T {
+        try _queue.sync {
+            var value = self._value
+            defer { self._value = value }
+            return try operation(&value)
+        }
+    }
+
+    public func setValue(_ newValue: Value) {
+        _queue.async {
+            self._value = newValue
+        }
+    }
+}
+
+
+extension QueueIsolated where Value == Int {
+    public func increment(by delta: Int = 1) {
+        withValue { $0 += delta }
+    }
+
+    public func decrement(by delta: Int = 1) {
+        withValue { $0 -= delta }
+    }
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,5 +22,5 @@ docker run \
   --rm \
   --volume "$(pwd):/src" \
   --workdir "/src" \
-  swift:5.10.0-amazonlinux2 \
+  swift:6.0.3-amazonlinux2 \
   swift build --disable-automatic-resolution --product "$executable" -c release --static-swift-stdlib #-Xswiftc -cross-module-optimization 


### PR DESCRIPTION
This should fix https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/3739#issuecomment-2742650337

Error is reproducible with our test file: https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252FDocUploaderLambda-Test-UploadFunction-A0zLSxC2sCV5/log-events/2025$252F03$252F21$252F$255B$2524LATEST$255D3d79f7ef55144aaa92632e8ee812fddf

![CleanShot 2025-03-21 at 14 28 55@2x](https://github.com/user-attachments/assets/5fc34629-35b8-44ba-be19-d8751fccdb37)

and fixed with the new version:

https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252FDocUploaderLambda-Test-UploadFunction-A0zLSxC2sCV5/log-events/2025$252F03$252F21$252F$255B$2524LATEST$255D2397d76ab2974cdf942db0b9562ed262

![CleanShot 2025-03-21 at 14 29 35@2x](https://github.com/user-attachments/assets/f7f2ac59-7397-4301-826c-b5868203a8d4)
